### PR TITLE
Fix step 11 (Family Characteristics) selection dialog

### DIFF
--- a/module/apps/charCreate.mjs
+++ b/module/apps/charCreate.mjs
@@ -696,7 +696,7 @@ export class PENCharCreate {
 
 
     } else {
-      let results =  table.results.toObject(false).filter (itm=>(itm.type > 0)).map(itm=> {return { name: itm.text, pid: itm._id}})
+      let results =  table.results.toObject(false).filter (itm=>(itm.type != 'text')).map(itm=> {return { name: itm.text, pid: itm._id}})
       selected = await PENCharCreate.selectFromRadio ('list',false,results)
       let res = table.results.toObject(false).filter (itm=>(itm._id === selected))[0]
       switch (res.type) {

--- a/templates/dialog/selectItem.html
+++ b/templates/dialog/selectItem.html
@@ -2,16 +2,13 @@
     <div class="stat-name">{{headTitle}}</div>
     <div class="radioList">
       {{#each newList as |type id|}}
-        <div class="stat-name">  
-          <input type="radio" id="{{type.name}}" name="selectItem" value={{type.pid}} {{#if (eq @index 0)}}checked{{/if}}></input>
-
-          {{#if (eq type.type 'trait')}}
-            <label for="resource-label-diff orderList">{{type.name}}  {{#if (ne type.system.religious 0)}}(R){{/if}}</label>
-          {{else}}
-            <label for="resource-label-diff orderList">{{type.name}}</label>  
-          {{/if}}  
-        </div>  
-      {{/each}}    
+        <div class="stat-name">
+          <label>
+            <input type="radio" id="{{type.name}}" name="selectItem" value={{type.pid}} {{#if (eq @index 0)}}checked{{/if}}></input>
+            {{type.name}}{{#if (eq type.type 'trait')}}  {{#if (ne type.system.religious 0)}}(R){{/if}}{{/if}}
+          </label>
+        </div>
+      {{/each}}
     </div>
     <br>
   </form>

--- a/templates/dialog/selectItem.html
+++ b/templates/dialog/selectItem.html
@@ -4,7 +4,7 @@
       {{#each newList as |type id|}}
         <div class="stat-name">
           <label>
-            <input type="radio" id="{{type.name}}" name="selectItem" value={{type.pid}} {{#if (eq @index 0)}}checked{{/if}}></input>
+            <input type="radio" name="selectItem" value={{type.pid}} {{#if (eq @index 0)}}checked{{/if}}></input>
             {{type.name}}{{#if (eq type.type 'trait')}}  {{#if (ne type.system.religious 0)}}(R){{/if}}{{/if}}
           </label>
         </div>


### PR DESCRIPTION
This PR fixes the filter used to get the list of options for the Step 11 (family characteristics) selection dialog, which otherwise blocks character creation.

It also fixes the template so that clicking on the radio button label works as expected. Using `type.name` generally creates invalid, non-unique IDs (which is what the `for` attribute is supposed to reference). Rather than solve the uniqueness problem, we can use the older method of nesting the radio button itself inside the label and remove the invalid attributes.