### PR TITLE
Update the passion dialog for winter training

### DIFF
--- a/css/pendragon.css
+++ b/css/pendragon.css
@@ -1341,3 +1341,15 @@ height: inherit;
     grid-template-columns: 14ch 4ch 55px 14ch 4ch 40px;
   }
 }
+.Pendragon .passion-name {
+  font-family: "Garamond";
+  font-size: 20px;
+  color: black;
+  padding-left: 1rem;
+}
+.Pendragon .court-name {
+  font-family: "Garamond";
+  font-size: 20px;
+  color: black;
+  text-transform: capitalize;
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -412,6 +412,7 @@
     "participantHint":"Enter the name of the participant, object etc",
     "passion": "Passion",
     "passions": "Passions",
+    "passionSpend": "Use the arrows to raise or lower your existing passions",
     "passive": "Passive Glory",
     "pen":"Pen",
     "penalty": "Penalty",

--- a/module/apps/passion-selection.mjs
+++ b/module/apps/passion-selection.mjs
@@ -1,0 +1,133 @@
+// this dialog is used to allocate points to passions
+// both raising and lowering passions costs points
+export class PassionsSelectDialog extends Dialog {
+  activateListeners(html) {
+    super.activateListeners(html);
+
+    html
+      .find(".up.rollable")
+      .click(async (event) => this._onSelectArrowClicked(event, 1));
+    html
+      .find(".down.rollable")
+      .click(async (event) => this._onSelectArrowClicked(event, -1));
+    html.find(".closecard").click(async (event) => this._shutdialog(event));
+  }
+
+  async _onSelectArrowClicked(event, change) {
+    const chosen = event.currentTarget.closest(".large-icon");
+    let choice = chosen.dataset.set;
+    let newCap = 0;
+    const chosenPassion = this.data.data.passions[choice];
+
+    //Normally stats only allowed in range min - max
+    // you can lower a passion that is already over the max
+    if (
+      chosenPassion.value + change <
+        chosenPassion.min ||
+      (chosenPassion.value + change >
+        chosenPassion.max && chosenPassion.value > chosenPassion.origValue)
+    ) {
+      change = 0;
+      return;
+    }
+
+    //Change the stat value & points spent
+    if (chosenPassion.value + change == chosenPassion.origValue)
+    {
+      newCap = this.data.data.added - Math.abs(change);
+      console.log(`cap: ${this.data.data.cap} change: ${change} newcap: ${newCap}`)
+    }
+    else
+    {
+      newCap = this.data.data.added + Math.abs(change);
+      console.log(`cap: ${this.data.data.cap} change: ${change} newcap: ${newCap}`)
+    }
+
+    //If you don't breach the Max Points then update (otherwise ignore)
+    if (newCap <= this.data.data.pointsMax) {
+      chosenPassion.value =
+        Number(chosenPassion.value) + change;
+      this.data.data.added = newCap;
+
+      //Update points spent and the stats value on the form
+      const form = event.currentTarget.closest(".stats-input");
+      const divCount = form.querySelector(".count");
+      divCount.innerText = this.data.data.added;
+      const statVal = form.querySelector(".item-" + choice);
+      statVal.innerText = chosenPassion.value;
+      const closecard = form.querySelector(".closecard");
+      const upArrow = form.querySelector(".inc-" + choice);
+      const downArrow = form.querySelector(".dec-" + choice);
+      if (
+        chosenPassion.value >=
+        chosenPassion.max && chosenPassion.value >= chosenPassion.origValue
+      ) {
+        upArrow.innerHTML = "&nbsp";
+      } else {
+        upArrow.innerHTML = "<i class='fas fa-circle-up'></i>";
+      }
+      if (
+        chosenPassion.value <=
+        chosenPassion.min && chosenPassion.value <= chosenPassion.origValue
+      ) {
+        downArrow.innerHTML = "&nbsp";
+      } else {
+        downArrow.innerHTML = "<i class='fas fa-circle-down'></i>";
+      }
+      if (newCap >= this.data.data.pointsMax) {
+        closecard.innerHTML =
+          "<button class='proceed cardbutton' type='button'>" +
+          game.i18n.localize("PEN.confirm") +
+          "</button>";
+      } else {
+        closecard.innerHTML =
+          "<button class='cardbutton' type='button'>" +
+          game.i18n.localize("PEN.spendPoints") +
+          "</button>";
+      }
+    }
+  }
+
+  async _shutdialog(event) {
+    if (this.data.data.added >= this.data.data.pointsMax) {
+      this.close();
+    }
+  }
+
+  static async create(title, passions, points, cap) {
+    let destination = "systems/Pendragon/templates/dialog/passionsInput.hbs";
+    let winTitle = title;
+    let data = {
+      courts: [
+        {name: "adoratio", label: game.i18n.localize("PEN.adoratio")},
+        {name:"civilitas", label: game.i18n.localize("PEN.civilitas")},
+        {name:"fervor", label: game.i18n.localize("PEN.fervor")},
+        {name:"fidelitas", label: game.i18n.localize("PEN.fidelitas")},
+        {name:"honor", label: game.i18n.localize("PEN.honor")}
+      ],
+      passions,
+      pointsMax: points,
+      added: 0,
+      cap: cap,
+    };
+    const html = await renderTemplate(destination, data);
+
+    return new Promise((resolve) => {
+      const dlg = new PassionsSelectDialog(
+        {
+          title: winTitle,
+          content: html,
+          data,
+          buttons: {},
+          close: () => {
+            if (data.added < data.pointsMax) return resolve(false);
+            const selected = data.passions;
+            return resolve(selected);
+          },
+        },
+        { classes: ["Pendragon", "dialog", "stats-select"] }
+      );
+      dlg.render(true);
+    });
+  }
+}

--- a/module/apps/winterPhase.mjs
+++ b/module/apps/winterPhase.mjs
@@ -1,6 +1,7 @@
 import { PENUtilities } from "./utilities.mjs";
 import { WinterSelectDialog } from "./winter-select-dialog.mjs";
 import { TraitsSelectDialog } from "./trait-selection.mjs";
+import { PassionsSelectDialog } from "./passion-selection.mjs";
 import { PENSelectLists } from "./select-lists.mjs";
 import { PENCheck } from '../apps/checks.mjs';
 import { PENCharCreate } from "./charCreate.mjs";
@@ -341,22 +342,25 @@ export class PENWinter {
     }
     let options = [];
     for (let i of this.actor.items) {
-      if (i.type === "passion") {
+      if (i.type === "passion" && i.system.value > 0) {
         let option = {
           'type': i.type,
           'label': game.i18n.localize("PEN."+i.type),
           'itemID': i._id,
-          'name' : i.name + " (" + i.system.value +")",
+          'name' : i.name,
           'value': i.system.value,
+          'origValue': i.system.value,
+          'court': i.system.court,
+          'level': i.system.level,
           'choice': "",
           'max': 20,
-          'min': 1
+          'min': 0
         }
 
-        // For passions range is 1-20 except for Prestige reward when there is no max or min
+        // For passions range is 0-20 except for Prestige reward when there is no max
         if (route === 'prestige'){
           option.max = 999;
-          option.min = -999;
+          option.min = 0;
         }
 
         options.push(option);
@@ -365,22 +369,14 @@ export class PENWinter {
 
     // Sort Options
     options.sort(function(a, b){
-      let x = a.name.toLowerCase();
-      let y = b.name.toLowerCase();
-      let p = a.label;
-      let q = b.label;
-      if (p < q) {return -1};
-      if (p > q) {return 1};
-      if (x < y) {return -1};
-      if (x > y) {return 1};
-      return 0;
+      return a.court.localeCompare(b.court) || a.label.localeCompare(b.label) || a.name.localeCompare(b.name);
     });
 
-    let amount = 1;
+    const amount = 1;
     let title = game.i18n.localize('PEN.prestigeAward');
     if (route != 'prestige') {title = game.i18n.localize('PEN.training')}
 
-    const selected = await WinterSelectDialog.create (title, options, this.actor.name, amount);
+    const selected = await PassionsSelectDialog.create (title, options, amount, 1);
       if (selected.length <1 || !selected) {
         ui.notifications.warn(game.i18n.localize('PEN.noSelection'));
         return

--- a/templates/dialog/passionsInput.hbs
+++ b/templates/dialog/passionsInput.hbs
@@ -1,0 +1,36 @@
+<form class="Pendragon stats-input" id="stats-input-form">
+  <br>
+
+  <div class="stats-input">{{localize 'PEN.passionSpend'}}</div>
+  <br>
+
+  <div class="flexcol">
+    <div class='bold statsCreate header counter'>
+      <label class="skill-opt-label">{{ localize 'PEN.pointsSpent' }}:</label>
+      <span class="centre count">{{added}}</span>
+      <span class="centre">/</span>
+      <span class="centre">{{pointsMax}}</span>
+    </div>
+    <br>
+
+  <div class="statsCreate">
+    {{#each courts as |court|}}
+    <h4 class="bold court-name">{{court.label}}</h4>
+    <div></div>
+    <div></div>
+    <div></div>
+    {{#each ../passions as |passion key|}}
+      {{#if (eq passion.court court.name)}}
+      <div class="bold passion-name">{{passion.name}}</div>
+      <div class="centre"><a class="large-icon darkred up rollable inc-{{key}}" data-set="{{key}}">{{#if (lt passion.value passion.max)}}<i class="fas fa-circle-up"></i>{{/if}}</a></div>
+      <div class="centre item-{{key}}">{{passion.value}}</div>
+      <div class="centre"><a class="large-icon darkred down rollable dec-{{key}}" data-set="{{key}}">{{#if (gt passion.value passion.min)}}<i class="fas fa-circle-down"></i>{{/if}}</a></div>
+      {{/if}}
+    {{/each}}
+    {{/each}}
+  </div>
+  <br>
+
+  <div class="closecard"><button class='cardbutton' type="button">{{localize 'PEN.spendPoints' }}</button></div>
+
+</form>


### PR DESCRIPTION
This switches passions to use a reworked dialog when training them:

* Specific instruction at the top of the page
* Group existing passions by courts
* Correctly allow raising and lowering of existing passions
* Capped at twenty for winter training, uncapped for prestige training

Passions are never raised from zero by training, though they can be lowered to zero by training. Passions are typically gained or lost through gameplay.