### PR TITLE
Add setting to disable child deaths

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -675,6 +675,8 @@
     "Settings": {
       "autoXP": "Automate XP",
       "autoXPHint": "Automatically grants XP checks for Success or Critical",
+      "childMortality": "Child Mortality",
+      "childMortalityHint": "When off, child survival rolls are skipped and childbirth tragedies are not possible.",
       "critAdj": "Critical Bonus Adjustment",
       "critAdjHint": "Reduce critical bonuses where all parties have a bonus",
       "diceRolls": "Dice Rolls",

--- a/module/apps/winterPhase.mjs
+++ b/module/apps/winterPhase.mjs
@@ -1014,7 +1014,7 @@ export class PENWinter {
     if (!this.actor.system.status.familyRoll) {return}
     //Child Survival Roll
     let children = this.actor.items.filter(itm=>itm.type==='family').filter(itm=>Number(itm.system.died) <1 && itm.system.relation==='child' && (game.settings.get('Pendragon','gameYear') - itm.system.born)<5 && !itm.system.blessed)
-    if (children.length > 0) {
+    if (children.length > 0 && game.settings.get('Pendragon', 'childMortality')) {
       let cldChng=[]
       for (const child of children) {
         let result = await PENUtilities.simpleDiceRoll('1D20')
@@ -1082,7 +1082,6 @@ export class PENWinter {
       let newborn = []
       let result = 0
       let firstConcept = 0
-      let diceRoll=""
       let childDies = false
       let motherDies = false
       let motherBarren = false
@@ -1132,7 +1131,7 @@ export class PENWinter {
           birthRes = 3
         } else if (result <= target || ['heir','conception'].includes(prestige)) {
           birthRes = 2
-        } else if (result === 20) {
+        } else if (result === 20 && game.settings.get('Pendragon', 'childMortality')) {
           birthRes = 0
         } else {
           birthRes = 1

--- a/module/setup/register-settings.mjs
+++ b/module/setup/register-settings.mjs
@@ -59,6 +59,15 @@ export function registerSettings () {
     default: 2000
   });
 
+  game.settings.register('Pendragon', "childMortality", {
+    name: "PEN.Settings.childMortality",
+    hint: "PEN.Settings.childMortalityHint",
+    scope: "world",
+    config: true,
+    type: Boolean,
+    default: true
+  });
+
   game.settings.register('Pendragon', "tokenVision", {
     name: "PEN.Settings.tokenVision",
     hint: "PEN.Settings.tokenVisionHint",


### PR DESCRIPTION
Because death by childbirth and the death of children can be quite upsetting for some, and something that should be story-driven for others, this PR adds a setting to disable the corresponding family rolls during the Winter Phase.

Specifically, turning off the "Child Mortality" setting causes child survival rolls to be skipped altogether, and causes any "tragedy" result during childbirth to be treated as "no conception".