### PR TITLE
Add yearAvailable to items (fixes #21)

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -417,6 +417,22 @@
     "pen":"Pen",
     "penalty": "Penalty",
     "pending": "Pending",
+    "period": {
+      "all": "All Periods",
+      "anarchy": "Anarachy Period",
+      "aurelius": "Aurelius Period",
+      "boyKing": "Boy King Period",
+      "conquest": "Conquest Period",
+      "constantin": "Constantin Period",
+      "grailQuest": "Grail Quest Period",
+      "romance": "Romance Period",
+      "tournament": "Tournament Period",
+      "twilight": "Twilight Period",
+      "tyrant": "Tyrant Period",
+      "uprising": "Uprising Period",
+      "uther": "Uther Period",
+      "vortigern": "Vortigern Period"
+    },
     "person": "Person",
     "personal": "Personal Details",
     "personality": "Personality",
@@ -623,6 +639,7 @@
     "xpRoll": "Experience Rolls",
     "y": "Y",
     "year": "Year",
+    "yearAvailable": "Year Available",
     "yes": "Yes",
 
     "card": {

--- a/module/apps/chronology.mjs
+++ b/module/apps/chronology.mjs
@@ -1,0 +1,38 @@
+export function yearToPeriod(year) {
+    if (year < 415)
+        return 'PEN.period.all';
+    switch (true) {
+        case (year >= 415 && year <= 438):
+            return "PEN.period.constantin";
+        case (year >= 439 && year <= 450):
+            return "PEN.period.vortigern";
+        case (year >= 451 && year <= 460):
+            return "PEN.period.tyrant";
+        case (year >= 461 && year <= 468):
+            return "PEN.period.uprising";
+        case (year >= 469 && year <= 479):
+            return "PEN.period.aurelius";
+        case (year >= 480 && year <= 495):
+            return "PEN.period.uther";
+        case (year >= 496 && year <= 509):
+            return "PEN.period.anarchy";
+        case (year >= 510 && year <= 518):
+            return "PEN.period.boyKing";
+        case (year >= 519 && year <= 528):
+            return "PEN.period.conquest";
+        case (year >= 529 && year <= 539):
+            return "PEN.period.romance";
+        case (year >= 540 && year <= 547):
+            return "PEN.period.tournament";
+        case (year >= 548 && year <= 557):
+            return "PEN.period.grailQuest";
+        case (year >= 558 && year <= 566):
+            return "PEN.period.twilight";
+        default:
+            return "PEN.period.twilight";
+    }
+}
+
+export function yearToPeriodName(year) {
+    return game.i18n.localize(yearToPeriod(year))
+}

--- a/module/item/sheets/item-sheet.mjs
+++ b/module/item/sheets/item-sheet.mjs
@@ -1,0 +1,76 @@
+import { yearToPeriodName } from "../../apps/chronology.mjs";
+const { api, sheets } = foundry.applications;
+
+
+export class PendragonItemSheet extends api.HandlebarsApplicationMixin(
+  sheets.ItemSheetV2
+) {
+  constructor(options = {}) {
+    super(options);
+  }
+
+  async _renderFrame(options) {
+    const frame = await super._renderFrame(options);
+    //define button
+    const sheetPID = this.item.flags?.Pendragon?.pidFlag;
+    const noId = (typeof sheetPID === 'undefined' || typeof sheetPID.id === 'undefined' || sheetPID.id === '');
+    //add button
+    const label = game.i18n.localize("PEN.PIDFlag.id");
+    const pidEditor = `<button type="button" class="header-control fa-solid fa-fingerprint ${noId ? 'edit-pid-warning' : 'edit-pid-exisiting'}"
+        data-action="editPid" data-tooltip="${label}" aria-label="${label}"></button>`;
+    let el = this.window.close;
+    while (el.previousElementSibling.localName === 'button') {
+      el = el.previousElementSibling;
+    }
+    el.insertAdjacentHTML("beforebegin", pidEditor);
+    return frame;
+  }
+
+  async _prepareContext(options) {
+    return {
+      editable: this.isEditable,
+      owner: this.document.isOwner,
+      limited: this.document.limited,
+      item: this.item,
+      system: this.item.system,
+      hasOwner: this.item.isEmbedded === true,
+      isGM: game.user.isGM,
+      fields: this.document.schema.fields,
+      period: yearToPeriodName(this.item.system.yearAvailable)
+    };
+  }
+
+  /**
+   * Handle changing a Document's image.
+   *
+   * @this PendragonItemSheet
+   * @param {PointerEvent} event   The originating click event
+   * @param {HTMLElement} target   The capturing HTML element which defined a [data-action]
+   * @returns {Promise}
+   * @protected
+   */
+  static async _onEditImage(event, target) {
+    const attr = target.dataset.edit;
+    const current = foundry.utils.getProperty(this.document, attr);
+    const { img } = this.document.constructor.getDefaultArtwork?.(this.document.toObject()) ??
+      {};
+    const fp = new FilePicker({
+      current,
+      type: 'image',
+      redirectToRoot: img ? [img] : [],
+      callback: (path) => {
+        this.document.update({ [attr]: path });
+      },
+      top: this.position.top + 39,
+      left: this.position.left + 9,
+    });
+    return fp.browse();
+  }
+
+  // handle editPid action
+  static _onEditPid(event) {
+    event.stopPropagation(); // Don't trigger other events
+    if ( event.detail > 1 ) return; // Ignore repeated clicks
+    new PIDEditor(this.item, {}).render(true, { focus: true })
+  }
+}

--- a/template.json
+++ b/template.json
@@ -188,7 +188,8 @@
         "denarii": 0,
         "description": "",
         "GMdescription": "",
-        "source": ""
+        "source": "",
+        "yearAvailable": 0
       }
     },
     "gear": {

--- a/templates/item/armour.attributes.hbs
+++ b/templates/item/armour.attributes.hbs
@@ -56,6 +56,10 @@
       <div class="stat-name left bold">{{localize 'PEN.notes'}}</div>
       <div class="stat-name-input {{#if (eq item.system.notes '')}} input-border {{/if}}"><input name="system.notes" type="text" value="{{item.system.notes}}"/></div>
 
+      <div class="stat-name left bold">{{localize 'PEN.yearAvailable'}}</div>
+      <div class="stat-name-input "><input name="system.yearAvailable" type="text" value="{{item.system.yearAvailable}}" data-dtype="Number"/></div>
+      <div class="stat-name left bold"></div>
+      <div class="stat-name">{{period}}</div>
     </div>
     {{#if hasOwner}}
       <br>

--- a/templates/item/history.attributes.hbs
+++ b/templates/item/history.attributes.hbs
@@ -19,7 +19,7 @@
       <br>
       <div class="stat-name left bold new-row">{{localize 'PEN.favourLevel'}}</div>
       <div class="stat-name-input centre"><input name="system.favourLevel" type="text" value="{{item.system.favourLevel}}" data-dtype="Number"/></div>
-    {{/if}}  
+    {{/if}}
 
   </div>
 </section>


### PR DESCRIPTION
This adds a new field to items, yearAvailable, so we can indicate when an item is normally first available. It defaults to zero, as suggested in #21 and there is a function that will translate a year to the corresponding Pendragon period.

As an initial experiment, we make it editable it only for Armour, so we can make decisions about how it should be edited and displayed on an item sheet.

By comparing it to game year setting, we could indicate if it is newly available or not yet available.

I also wonder if it is desirable to either have a lock/unlock setting for items sheets in general (with only the GM/owner able to unlock it for editing), or a "preview" tab to figure out what a normal player sees.