### PR TITLE
Adjust selectivity of dark mode override

### DIFF
--- a/css/pendragon.css
+++ b/css/pendragon.css
@@ -1374,9 +1374,11 @@ height: inherit;
 
 /* Dark theme */
 .system-Pendragon.theme-dark {
+  .Pendragon {
   --color-text-primary: #000;
   --color-text-emphatic: #000;
   --color-text-secondary: #333;
+  }
 }
 
 /*  combat tracker for seating */


### PR DESCRIPTION
We're still forcing the system to ignore dark mode, just being a little more selective to avoid accidentally affecting things that aren't part of the system.