### PR TITLE
Improve feast support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 13.1.31-dev
+- Remember if an encounter is a skirmish or a feast
+- V13: track geniality via the combat tracker during a feast
+- V13: allow GM to move feast participant seating via context menu
+
 ## 13.1.30
 - Complete migration of item sheets to V2 Application
 - Ensure all V2 item sheets can be resized like their V1 counterparts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 13.1.31-dev
 - Remember if an encounter is a skirmish or a feast
-- V13: track geniality via the combat tracker during a feast
-- V13: allow GM to move feast participant seating via context menu
+- Allow GM to move feast participant seating via context menu
+- Track geniality via the combat tracker during a feast
 
 ## 13.1.30
 - Complete migration of item sheets to V2 Application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 13.1.31-dev
 - Remember if an encounter is a skirmish or a feast
+- Show the initiative roll for feast seating in the chat
 - Allow GM to move feast participant seating via context menu
 - Track geniality via the combat tracker during a feast
 

--- a/css/pendragon.css
+++ b/css/pendragon.css
@@ -1421,6 +1421,10 @@ height: inherit;
   }
 }
 
+.system-Pendragon .token-geniality {
+  max-width: 3em;
+}
+
 /* v13 tweaks */
 .Pendragon.item .sheet-header {
   display: flex;

--- a/css/pendragon.css
+++ b/css/pendragon.css
@@ -1423,6 +1423,10 @@ height: inherit;
 
 .system-Pendragon .token-geniality {
   max-width: 3em;
+  input{
+    color: var(--color-text-primary);
+    text-align: end;
+  }
 }
 
 /* v13 tweaks */

--- a/css/pendragon.css
+++ b/css/pendragon.css
@@ -1395,7 +1395,8 @@ height: inherit;
 
 /*  combat tracker for seating */
 .system-Pendragon h3.combat-tracker-header {
-  margin: 0;
+  margin: 0 0 0.5em;
+  font-size: larger;
 }
 .system-Pendragon .seating {
   display: list-item;
@@ -1405,17 +1406,18 @@ height: inherit;
   list-style: none;
   margin: 0;
   padding: 0;
-  border-bottom: 2px groove var(--color-border-dark-4);
+  border-bottom: 2px groove var(--color-dark-4);
 }
 
 .system-Pendragon .pendragon-combat-extras {
   margin: 0;
-  border-top: 2px groove var(--color-border-dark-4);
+  border-block: 2px groove var(--color-dark-4);
   & a.center {
     flex:3;
     font-size: var(--font-size-20);
     text-align: center;
     line-height: var(--sidebar-header-height);
+    color: var(--color-text-primary);
   }
 }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -233,7 +233,12 @@
       "onFloor": "On the Floor",
       "moveCloser": "Move to higher seat",
       "moveFurther": "Move to lower seat",
-      "begin": "Start Feast"
+      "begin": "Start Feast",
+      "reroll": "Fumble: rolling again and shifting result down a level",
+      "resultLevel.0": "Seated on the floor with the squires",
+      "resultLevel.1": "Seated further from the salt",
+      "resultLevel.2": "Seated closer to the salt",
+      "resultLevel.3": "Seated above the salt"
     },
     "features": "Features",
     "female": "Female",

--- a/lang/en.json
+++ b/lang/en.json
@@ -230,7 +230,10 @@
       "aboveSalt": "Above the Salt",
       "closeSalt": "Closer to the Salt",
       "farSalt": "Further from the Salt",
-      "onFloor": "On the Floor"
+      "onFloor": "On the Floor",
+      "moveCloser": "Move to higher seat",
+      "moveFurther": "Move to lower seat",
+      "begin": "Start Feast"
     },
     "features": "Features",
     "female": "Female",
@@ -244,6 +247,7 @@
     "follower": "Follower",
     "gender": "Gender",
     "genderResult": "Gender Result",
+    "geniality": "Geniality",
     "genSkills": "Calculate Base Scores",
     "glory": "Glory",
     "gloryAward":"Glory Award",

--- a/module/apps/checks.mjs
+++ b/module/apps/checks.mjs
@@ -42,32 +42,34 @@ export class PENCheck {
   }
 
   // shortcut to make direct roll (no dialog)
+  // use just output.resultLevel for success/failure
+  // or use full output structure to populate chat template
   static async makeDirectRoll(actor, rollType, cardType) {
     const options = {
       actor,
       rollType,
       cardType,
     };
-    const config = await this.normaliseRequest(options);
+    const output = await this.normaliseRequest(options);
     //Adjust target Score for check Bonus, reflexive Modifier and calculate critBonus where target score > 20 or <0
-    config.targetScore =
-      Number(config.targetScore) +
-      Number(config.flatMod) +
-      Number(config.reflexMod);
-    config.grossTarget = config.targetScore;
-    if (config.targetScore > 20) {
-      config.critBonus = config.targetScore - 20;
-      config.targetScore = 20;
-    } else if (config.targetScore < 0) {
-      config.critBonus = -config.targetScore;
-      config.targetScore = 0;
+    output.targetScore =
+      Number(output.targetScore) +
+      Number(output.flatMod) +
+      Number(output.reflexMod);
+    output.grossTarget = output.targetScore;
+    if (output.targetScore > 20) {
+      output.critBonus = output.targetScore - 20;
+      output.targetScore = 20;
+    } else if (output.targetScore < 0) {
+      output.critBonus = -output.targetScore;
+      output.targetScore = 0;
     }
 
     // make the roll (which updates the config result values)
-    await PENCheck.makeRoll(config);
+    await PENCheck.makeRoll(output);
     // TODO: we need a lot more if we're showing the result
     // which we almost definitely need for player-initiated rolls
-    return config.resultLevel;
+    return output;
   }
 
   //Check the request and build out the config

--- a/module/apps/combat-tracker.mjs
+++ b/module/apps/combat-tracker.mjs
@@ -28,7 +28,10 @@ export class PendragonCombatTracker extends (foundry.applications?.sidebar?.tabs
         const combatantId = row.dataset.combatantId ?? "";
         const combatant = this.viewed.combatants.get(combatantId, { strict: true });
         const init = row.querySelector(".token-initiative span");
-        if (init) init.innerText = combatant.actor.system.glory.toLocaleString();
+        if (init) {
+          init.innerText = combatant.actor.system.glory.toLocaleString();
+          this.#addGenialityVal(init, combatant);
+        }
         // Adjust controls with system extensions
         for (const controlIcon of row.querySelectorAll(".combatant-control.icon")) {
 
@@ -42,6 +45,14 @@ export class PendragonCombatTracker extends (foundry.applications?.sidebar?.tabs
         }
       }
     }
+  }
+
+  #addGenialityVal(selectedElement, combatant) {
+    const d = document.createElement("div");
+    const geniality = combatant.getGeniality();
+    d.classList.add("token-geniality");
+    d.innerHTML = `<span>${geniality}</span>`;
+    selectedElement.insertAdjacentElement("afterend", d);
   }
 
   #addSeating(list, label, combatants, rollNeeded) {
@@ -60,22 +71,22 @@ export class PendragonCombatTracker extends (foundry.applications?.sidebar?.tabs
     const a = document.createElement("a");
     a.classList.add("combat-control", "center");
     a.setAttribute("role", "button");
-    a.dataset.control = "switchEncounterType";
+    a.dataset.action = "switchEncounterType";
     if (encounter.isFeast()) {
       a.innerText = game.i18n.localize("PEN.encounterSwitchSkirmish");
     }
     else {
       a.innerText = game.i18n.localize("PEN.encounterSwitchFeast");
     }
-    a.addEventListener("click", event => {
-      encounter.switchEncounterType();
-      if (encounter.isFeast()) {
-        event.target.innerText = game.i18n.localize("PEN.encounterSwitchSkirmish");
-      }
-      else {
-        event.target.innerText = game.i18n.localize("PEN.encounterSwitchFeast");
-      }
-    });
+    // a.addEventListener("click", event => {
+    //   encounter.switchEncounterType();
+    //   if (encounter.isFeast()) {
+    //     event.target.innerText = game.i18n.localize("PEN.encounterSwitchSkirmish");
+    //   }
+    //   else {
+    //     event.target.innerText = game.i18n.localize("PEN.encounterSwitchFeast");
+    //   }
+    // });
     nav.append(a);
     return nav;
   }

--- a/module/combat/combat.mjs
+++ b/module/combat/combat.mjs
@@ -1,6 +1,7 @@
 import { PENCheck, RollType, CardType, RollResult } from "../apps/checks.mjs";
 
 export class PendragonCombat extends Combat {
+
   // for now we use 'skirmish' for standard Combat
   // and 'feast' for feast rules
   isFeast() {

--- a/module/combat/combat.mjs
+++ b/module/combat/combat.mjs
@@ -3,20 +3,19 @@ import { PENCheck, RollType, CardType, RollResult } from "../apps/checks.mjs";
 export class PendragonCombat extends Combat {
   // for now we use 'skirmish' for standard Combat
   // and 'feast' for feast rules
-  encounterType = "skirmish";
-
   isFeast() {
-    return this.encounterType == "feast";
+    return this.getFlag("Pendragon", "encounterType") == "feast";
   }
 
   switchEncounterType() {
     if (this.isFeast()) {
-      this.encounterType = "skirmish";
+      this.setFlag("Pendragon", "encounterType", "skirmish");
     }
     else{
-      this.encounterType = "feast";
+      this.setFlag("Pendragon", "encounterType", "feast");
     }
     ui.combat.initialize();
+    //if ( ui.combat.viewed === this ) ui.combat.render();
   }
 
   async rollInitiative(
@@ -82,5 +81,21 @@ export class PendragonCombat extends Combat {
     // Update multiple combatants
     await this.updateEmbeddedDocuments("Combatant", updates);
     return this;
+  }
+
+  async startCombat()
+  {
+    // set combatants to initial geniality
+    this.combatants.forEach(c => c.initGeniality());
+    // update on next round / previous round
+    super.startCombat();
+  }
+
+  nextRound()
+  {
+    if(this.isFeast()) {
+      this.combatants.forEach(c => c.addGeniality(Math.floor(c.initiative) - 1));
+    }
+    super.nextRound();
   }
 }

--- a/module/combat/combat.mjs
+++ b/module/combat/combat.mjs
@@ -44,23 +44,31 @@ export class PendragonCombat extends Combat {
     ids = typeof ids === "string" ? [ids] : ids;
     //const currentId = this.combatant?.id;
     const updates = [];
+    const messages = [];
     for (let [i, id] of ids.entries()) {
       // Get Combatant data (non-strictly)
       const combatant = this.combatants.get(id);
       if (!combatant?.isOwner) continue;
       // unopposed glory roll
-      let level = await PENCheck.makeDirectRoll(
+      const rolldata = await PENCheck.makeDirectRoll(
         combatant.actor,
         RollType.GLORY,
         CardType.UNOPPOSED,
       );
+      let level = rolldata.resultLevel;
       // Fumble = reroll but reduce level by 1
       if (level == RollResult.FUMBLE) {
-        level = await PENCheck.makeDirectRoll(
+        rolldata.firstRoll = rolldata.rollVal;
+        rolldata.firstResultLabel = game.i18n.localize('PEN.resultLevel.'+ level);;
+        rolldata.firstRollResult = rolldata.rollResult;
+        const reroll = await PENCheck.makeDirectRoll(
           combatant.actor,
           RollType.GLORY,
           CardType.UNOPPOSED,
         );
+        rolldata.rollVal = reroll.rollVal;
+        rolldata.rollResult = reroll.rollResult;
+        level = reroll.resultLevel;
         if (level > RollResult.FUMBLE) {
           level -= 1;
         }
@@ -68,19 +76,43 @@ export class PendragonCombat extends Combat {
       // Above = crit
       // Closer = success
       // Further = fail
-      // TODO: small feast move up one level of success
-      // TODO: royal feast above and closer move down one level
-      // we want to use glory as the tiebreaker
+      // using glory as the tiebreaker
       const fractionalGlory = combatant.actor.system.glory / 100_000;
-      var gloryRoll = updates.push({
+      updates.push({
         _id: id,
         initiative: level + fractionalGlory,
       });
+
+      // Construct chat message data
+      const messageData = foundry.utils.mergeObject({
+        speaker: ChatMessage.getSpeaker({
+          actor: combatant.actor,
+          token: combatant.token,
+          alias: combatant.name
+        }),
+        flavor: game.i18n.format("COMBAT.RollsInitiative", {name: combatant.name}),
+        flags: {"core.initiativeRoll": true}
+      }, messageOptions);
+      // ensure we use the adjusted result level
+      rolldata.resultLabel = game.i18n.localize('PEN.resultLevel.'+ level);
+      rolldata.resultLevel = level;
+      rolldata.seatingLabel = game.i18n.localize('PEN.feast.resultLevel.'+ level);
+    // Prepare chat data
+      const chatData = foundry.utils.mergeObject({
+        author: game.user.id,
+        content: await renderTemplate('systems/Pendragon/templates/chat/feast-seating.hbs', {chatCard: [rolldata]}),
+        // Play 1 sound for the whole rolled set
+        sound: i == 0 ? CONFIG.sounds.dice : null
+      }, messageData);
+
+      messages.push(chatData);
     }
     if (!updates.length) return this;
 
     // Update multiple combatants
     await this.updateEmbeddedDocuments("Combatant", updates);
+    // publish the roll results
+    await ChatMessage.implementation.create(messages);
     return this;
   }
 

--- a/module/combat/combatant.mjs
+++ b/module/combat/combatant.mjs
@@ -6,4 +6,23 @@ export class PendragonCombatant extends Combatant {
   getInitiativeRoll(formula) {
     return new Roll(`${this.actor.system.stats.dex.value}`);
   }
+
+  _onCreate(data, options, userID) {
+    super._onCreate(data, options, userID);
+    this.setFlag("Pendragon", "geniality", 1);
+  }
+
+  initGeniality() {
+    // based on clothing, setting to one to reflect
+    // ordinary standard of living
+    this.setFlag("Pendragon", "geniality", 1);
+  }
+  getGeniality() {
+    return this.getFlag("Pendragon", "geniality") || 0;
+  }
+  addGeniality(val) {
+    const curr = this.getFlag("Pendragon", "geniality") || 0;
+    this.setFlag("Pendragon", "geniality", curr + val);
+  }
+
 }

--- a/templates/chat/feast-seating.hbs
+++ b/templates/chat/feast-seating.hbs
@@ -1,0 +1,72 @@
+<form class="Pendragon">
+  <div class="">
+    <ol class="op-list">
+      {{#each chatCard as |c key|}}
+        <div class="dice-roll" data-action="expandRoll">
+          <li class='actor-roll'>
+            <img class="open-actor" src="{{c.particImg}}" height="50" width="50" title="{{c.particName}}"/>
+            <div class="roll-details">
+              <div class="header">
+                <div class='name'>
+                  <span class="tag">{{c.particName}} FEAST</span>
+                </div>
+              </div>
+              <div class="header">
+                <div class='name'>
+                  <span class="tag">{{c.label}} ({{c.targetScore}})</span>
+                </div>
+              </div>
+              {{#if c.firstRoll}}
+              <span class="pending">{{c.firstResultLabel}}: {{c.firstRoll}} <i class=" result-fail fas fa-skull"></i><i class="result-fail fas fa-skull"></i></span>
+              <div class="flavor-text">{{localize 'PEN.feast.reroll'}}</div>
+              {{/if}}
+
+              {{#if (eq c.resultLevel 4)}}
+                <span class="pending">{{c.resultLabel}}: {{c.rollVal}} <i class="result-success fas fa-swords"></i><i class="result-success fas fa-swords"></i><i class="result-success fas fa-swords"></i></span>
+              {{/if}}
+
+              {{#if (eq c.resultLevel 3)}}
+                <span class="pending">{{c.resultLabel}}: {{c.rollVal}} <i class="result-success fas fa-swords"></i><i class="result-success fas fa-swords"></i></span>
+              {{/if}}
+
+              {{#if (eq c.resultLevel 2)}}
+                <span class="pending">{{c.resultLabel}}: {{c.rollVal}} <i class="result-success fas fa-swords"></i></span>
+              {{/if}}
+
+              {{#if (eq c.resultLevel 1)}}
+                <span class="pending">{{c.resultLabel}}: {{c.rollVal}} <i class="result-fail fas fa-skull"></i></span>
+              {{/if}}
+
+              {{#if (eq c.resultLevel 0)}}
+                <span class="pending">{{c.resultLabel}}: {{c.rollVal}} <i class=" result-fail fas fa-skull"></i><i class="result-fail fas fa-skull"></i></span>
+              {{/if}}
+              <div class="flavor-text">{{c.seatingLabel}}</div>
+            </div>
+
+
+          </li>
+          <div class="actor-roll dice-tooltip">
+            <div class="owner-only" data-partic-id="{{c.particId}}" data-partic-type="{{c.particType}}">
+              <div class="rollHidden">{{localize 'PEN.rawScore'}}: {{c.rawScore}}</div>
+              <div class="rollHidden"> {{localize 'PEN.bonus'}}:
+                {{#if (lt c.flatMod 1)}}
+                  {{c.flatMod}}
+                {{else}}
+                  +{{c.flatMod}}
+                {{/if}}
+              </div>
+              <div class="rollHidden"> {{localize 'PEN.critBonus'}}:
+                {{#if (lt c.critBonus 1)}}
+                  {{c.critBonus}}
+                {{else}}
+                  +{{c.critBonus}}
+                {{/if}}
+              </div>
+              <div class="rollHidden bottom-line">{{localize 'PEN.diceRoll'}}: {{c.rollResult}}</div>
+            </div>
+          </div>
+        </div>
+      {{/each}}
+    </ol>
+  </div>
+</form>

--- a/templates/sidebar/combat/footer.hbs
+++ b/templates/sidebar/combat/footer.hbs
@@ -1,0 +1,50 @@
+<nav class="combat-controls" data-tooltip-direction="UP">
+    {{~#if hasCombat~}}
+
+    {{!-- GM Controls --}}
+    {{#if user.isGM}}
+    {{#if combat.round}}
+    <button type="button" class="inline-control combat-control icon fa-solid fa-backward-step"
+            data-action="previousRound" data-tooltip aria-label="{{ localize "COMBAT.RoundPrev" }}"></button>
+    <button type="button" class="inline-control combat-control icon fa-solid fa-arrow-left" data-action="previousTurn"
+            data-tooltip aria-label="{{ localize "COMBAT.TurnPrev" }}"></button>
+    <button type="button" class="combat-control combat-control-lg" data-action="endCombat">
+        <i class="fa-solid fa-xmark" inert></i>
+        <span>{{ localize "COMBAT.End" }}</span>
+    </button>
+    <button type="button" class="inline-control combat-control icon fa-solid fa-arrow-right" data-action="nextTurn"
+            data-tooltip aria-label="{{ localize "COMBAT.TurnNext" }}"></button>
+    <button type="button" class="inline-control combat-control icon fa-solid fa-forward-step" data-action="nextRound"
+            data-tooltip aria-label="{{ localize "COMBAT.RoundNext" }}"></button>
+    {{else}}
+    <button type="button" class="combat-control center" data-action="switchEncounterType">
+        {{#if (eq combat.flags.Pendragon.encounterType "feast")}}
+        <span>{{ localize "PEN.encounterSwitchSkirmish" }}</span>
+        {{else}}
+        <span>{{ localize "PEN.encounterSwitchFeast" }}</span>
+        {{/if}}
+    </button>
+    <button type="button" class="combat-control combat-control-lg" data-action="startCombat">
+        {{#if (eq combat.flags.Pendragon.encounterType "feast")}}
+        <i class="fa-solid fa-party-horn" inert></i>
+        <span>{{ localize "PEN.feast.begin" }}</span>
+        {{else}}
+        <i class="fa-solid fa-swords" inert></i>
+        <span>{{ localize "COMBAT.Begin" }}</span>
+        {{/if}}
+    </button>
+    {{/if}}
+
+    {{!-- Active Player Controls --}}
+    {{else if control}}
+    <button type="button" class="inline-control combat-control icon fa-solid fa-arrow-left" data-action="previousTurn"
+            data-tooltip aria-label="{{ localize "COMBAT.TurnPrev" }}"></button>
+    <button type="button" class="combat-control combat-control-lg" data-action="nextTurn">
+        <i class="fa-solid fa-check"></i>
+        <span>{{ localize "COMBAT.TurnEnd" }}</span>
+    </button>
+    <button type="button" class="inline-control combat-control icon fa-solid fa-arrow-right" data-action="nextTurn"
+            data-tooltip aria-label="{{ localize "COMBAT.TurnNext" }}"></button>
+    {{/if}}
+    {{/if}}
+</nav>


### PR DESCRIPTION
This refines the initial feast support to provide better visibility into the workings. Tested on v12 and v13.

* The results of rolling for seating are made visible in the chat.
* The context menu for participants now allows the GM to adjust seating.
* Geniality is tracked per-participant in the combat tracker
* Geniality is automatically updated at the start of a round per seating rules.
* If an encounter is marked as a feast, this will be remembered properly.

