### PR TITLE
Fix up GM Tools layer interactions (Fixes #62)

### DIFF
--- a/module/pendragon.mjs
+++ b/module/pendragon.mjs
@@ -50,6 +50,8 @@ Hooks.once("init", async function () {
   if (V13) {
     CONFIG.ui.combat = PendragonCombatTracker;
     CONFIG.Canvas.layers.pendragonmenu = {group: 'interface', layerClass: PENLayer};
+    // hides the dummy menu item
+    Hooks.on("renderSceneControls", PENLayer.renderControls);
   } else {
     CONFIG.ui.combat = PendragonCombatTrackerV12;
     // v12 Add GM Tool Layer

--- a/module/setup/layers.mjs
+++ b/module/setup/layers.mjs
@@ -3,27 +3,32 @@ import { PENCharCreate } from "../apps/charCreate.mjs";
 import { PENRollType } from "../cards/rollType.mjs";
 
 
-export class PENLayer extends PlaceablesLayer {
+export class PENLayer extends InteractionLayer {
 
   constructor () {
     super()
-    this.objects = {}
   }
 
   static get layerOptions () {
     return foundry.utils.mergeObject(super.layerOptions, {
-      name: 'pendragonmenu',
-      zIndex: 60
+      name: 'pendragonmenu'
     })
   }
 
-  static get documentName () {
-    return 'Token'
+  // hide the dummy tool
+  static renderControls (app, html, data) {
+    const dummy_item = html.querySelector('[data-tool="pendummy"]');
+    if(dummy_item) {
+      dummy_item.parentElement.remove();
+    }
   }
 
-  get placeables () {
-    return []
+  // we don't have any interactive children for this layer
+  // so turn this flag back off when activated
+  _activate() {
+    this.interactiveChildren = false;
   }
+
   static prepareSceneControls() {
     return {
       icon: "fas fa-tools",
@@ -32,13 +37,20 @@ export class PENLayer extends PlaceablesLayer {
       title: 'PEN.GMTools',
       visible: game.user.isGM,
       order: 11,
-      activeTool: '',
-      onChange: (event, active) => {
-        if ( active )
-        canvas.pendragonmenu.activate();
-      },
-      onToolChange: () => canvas.pendragonmenu.setAllRenderFlags({refreshState: true}),
+      activeTool: 'pendummy',
+      onChange: () => {},
+      onToolChange: () => {},
       tools: {
+        // this dummy tool exists because we have no sensible default tool when switching to this layer
+        // it is hidden by the "PENLayer.renderControls" hook
+        pendummy: {
+          name: "pendummy",
+          order: 0,
+          icon: "",
+          title:  '',
+          button: true,
+          onChange: async (event, toggle) => {},
+        },
         winter: {
           name: "winter",
           order: 1,


### PR DESCRIPTION
The GM Tools layer was incorrectly marked as a `PlaceablesLayer` associated to Token documents; in V13 this resulted in token frames behaving oddly.

In addition, in V13 the layer menu expects a default tool to be selected; not having one selected when attempting to switch to another layer throws an exception as reported in #62 

This PR changes the layer type to an `InteractionLayer` without any interactive children, which fixes the issue with token frames. It also adds (and hides) a default dummy tool which satisfies the behaviour expected by the layer menu.