### PR TITLE
Chaosium Canvas Interface: Play Sound, Button Triggers, duplicate Region Behaviours

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -810,7 +810,16 @@
       "woodcraft": "Woodcraft"      
     },
     "ChaosiumCanvasInterface": {
+      "Buttons": {
+        "Both": "Both Mouse Buttons",
+        "Left": "Left Mouse Button",
+        "Right": "Right Mouse Button"
+      },
       "DrawingToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the drawings and documents"
@@ -835,16 +844,36 @@
           "Title": "Permission for Documents",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       },
       "MapPinToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the map pin and documents"
@@ -867,6 +896,10 @@
         }
       },
       "OpenDocument": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Permission": {
           "Title": "Can click if",
           "Hint": ""
@@ -886,7 +919,29 @@
         "GM": "Keeper",
         "SeeTile": "See Tile"
       },
+      "PlaySound": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
+        "Playlist": {
+          "Title": "Select Playlist",
+          "Hint": ""
+        },
+        "Sound": {
+          "Title": "Select Playlist Sound",
+          "Hint": ""
+        },
+        "Toggle": {
+          "Title": "Play",
+          "Hint": "Should this play or stop playback"
+        }
+      },
       "ToScene": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Permission": {
           "Title": "Can click if",
           "Hint": ""
@@ -901,6 +956,10 @@
         }
       },
       "TileToggle": {
+        "Button": {
+          "Title": "Mouse Button",
+          "Hint": "Which button should trigger this behavior"
+        },
         "Toggle": {
           "Title": "Show",
           "Hint": "Should this show or hide the tile and documents"
@@ -925,12 +984,28 @@
           "Title": "Permission for Documents",
           "Hint": "When set to show set Document ownership to this level"
         },
+        "PermissionDocumentHide": {
+          "Title": "Hide Permission for Journal Entries",
+          "Hint": "When set to hide set Document ownership to this level"
+        },
         "PermissionPage": {
           "Title": "Permission for Journal Entry Pages",
           "Hint": "When set to show set Journal Entry Page ownership to this level"
         },
-        "RegionUuids": {
-          "Title": "Then trigger these CCI Regions on Right Click",
+        "PermissionPageHide": {
+          "Title": "Hide Permission for Journal Entry Pages",
+          "Hint": "When set to hide set Journal Entry Page ownership to this level"
+        },
+        "TriggerButton": {
+          "Title": "Trigger Region Button",
+          "Hint": "If Mouse Button is Both, and this button is used trigger the following region"
+        },
+        "TriggerRegionUuids": {
+          "Title": "Trigger This Region",
+          "Hint": ""
+        },
+        "TriggerAsButton": {
+          "Title": "With A Button Click",
           "Hint": ""
         }
       }
@@ -964,6 +1039,7 @@
       "ChaosiumCanvasInterfaceDrawingToggle": "CCI: Drawing Toggle",
       "ChaosiumCanvasInterfaceMapPinToggle": "CCI: Map Note Toggle",
       "ChaosiumCanvasInterfaceOpenDocument": "CCI: Open Document",
+      "ChaosiumCanvasInterfacePlaySound": "CCI: Play Sound",
       "ChaosiumCanvasInterfaceToScene": "CCI: To Scene",
       "ChaosiumCanvasInterfaceTileToggle": "CCI: Tile Toggle"
     }

--- a/module/apps/chaosium-canvas-interface-drawing-toggle.mjs
+++ b/module/apps/chaosium-canvas-interface-drawing-toggle.mjs
@@ -15,9 +15,27 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
     return 'fa-solid fa-pencil'
   }
 
+  static get triggerButtons () {
+    const buttons = super.triggerButtons
+    buttons[ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both] = 'PEN.ChaosiumCanvasInterface.Buttons.Both'
+    return buttons
+  }
+
+  static get triggerButton () {
+    const button = super.triggerButton
+    button.Both = 20
+    return button
+  }
+
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterfaceDrawingToggle.triggerButtons,
+        initial: ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Left,
+        label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.Button.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.Button.Hint'
+      }),
       toggle: new fields.BooleanField({
         initial: false,
         label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.Toggle.Title',
@@ -48,6 +66,13 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.PermissionDocument.Hint',
         required: true
       }),
+      permissionDocumentHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.PermissionDocumentHide.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.PermissionDocumentHide.Hint',
+        required: true
+      }),
       journalEntryPageUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'JournalEntryPage'
@@ -64,6 +89,13 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.PermissionPage.Hint',
         required: true
       }),
+      permissionPageHide: new fields.NumberField({
+        choices: Object.keys(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceDrawingToggle.PERMISSIONS[k]); return c }, {}),
+        initial: CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE,
+        label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.PermissionPageHide.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.PermissionPageHide.Hint',
+        required: true
+      }),
       regionBehaviorUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'RegionBehavior'
@@ -73,23 +105,42 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
           hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.RegionBehavior.Hint'
         }
       ),
+      regionButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Right,
+        label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.TriggerButton.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.TriggerButton.Hint'
+      }),
       regionUuids: new fields.SetField(
         new fields.DocumentUUIDField({
           type: 'Region'
         }),
         {
-          label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.RegionUuids.Title',
-          hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.RegionUuids.Hint'
+          label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.TriggerRegionUuids.Title',
+          hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.TriggerRegionUuids.Hint'
         }
       ),
+      triggerAsButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'PEN.ChaosiumCanvasInterface.DrawingToggle.TriggerAsButton.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.DrawingToggle.TriggerAsButton.Hint'
+      }),
     }
+  }
+
+  static migrateData (source) {
+    if (typeof source.triggerButton === 'undefined' && source.regionUuids?.length) {
+      source.triggerButton = ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both
+    }
+    return source
   }
 
   async _handleMouseOverEvent () {
     return game.user.isGM
   }
 
-  async _handleLeftClickEvent () {
+  async #handleClickEvent (button) {
     for (const uuid of this.drawingUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -98,8 +149,8 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         console.error('Drawing ' + uuid + ' not loaded')
       }
     }
-    const permissionDocument = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionDocument)
-    const permissionPage = (!this.toggle ? CONST.DOCUMENT_OWNERSHIP_LEVELS.NONE : this.permissionPage)
+    const permissionDocument = (!this.toggle ? this.permissionDocumentHide : this.permissionDocument)
+    const permissionPage = (!this.toggle ? this.permissionPageHide : this.permissionPage)
     for (const uuid of this.journalEntryUuids) {
       const doc = await fromUuid(uuid)
       if (doc) {
@@ -124,14 +175,30 @@ export default class ChaosiumCanvasInterfaceDrawingToggle extends ChaosiumCanvas
         console.error('Region Behavior ' + uuid + ' not loaded')
       }
     }
+    if (this.triggerButton === ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both) {
+      for (const uuid of this.regionUuids) {
+        setTimeout(() => {
+          if (button === this.regionButton) {
+            if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Right) {
+              game.Pendragon.ClickRegionRightUuid(uuid)
+            } else if (this.triggerAsButton === ChaosiumCanvasInterface.triggerButton.Left) {
+              game.Pendragon.ClickRegionLeftUuid(uuid)
+            }
+          }
+        }, 100)
+      }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if ([ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both, ChaosiumCanvasInterface.triggerButton.Left].includes(this.triggerButton)) {
+      this.#handleClickEvent(ChaosiumCanvasInterface.triggerButton.Left)
+    }
   }
 
   async _handleRightClickEvent () {
-    await this._handleLeftClickEvent()
-    for (const uuid of this.regionUuids) {
-      setTimeout(() => {
-        game.Pendragon.ClickRegionLeftUuid(uuid)
-      }, 100)
+    if ([ChaosiumCanvasInterfaceDrawingToggle.triggerButton.Both, ChaosiumCanvasInterface.triggerButton.Right].includes(this.triggerButton)) {
+      this.#handleClickEvent(ChaosiumCanvasInterface.triggerButton.Right)
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface-init.mjs
+++ b/module/apps/chaosium-canvas-interface-init.mjs
@@ -1,6 +1,7 @@
 import ChaosiumCanvasInterfaceDrawingToggle from "./chaosium-canvas-interface-drawing-toggle.mjs";
 import ChaosiumCanvasInterfaceMapPinToggle from "./chaosium-canvas-interface-map-pin-toggle.mjs";
 import ChaosiumCanvasInterfaceOpenDocument from "./chaosium-canvas-interface-open-document.mjs";
+import ChaosiumCanvasInterfacePlaySound from "./chaosium-canvas-interface-play-sound.mjs";
 import ChaosiumCanvasInterfaceToScene from "./chaosium-canvas-interface-to-scene.mjs";
 import ChaosiumCanvasInterfaceTileToggle from "./chaosium-canvas-interface-tile-toggle.mjs";
 import ChaosiumCanvasInterface from "./chaosium-canvas-interface.mjs";
@@ -11,6 +12,7 @@ export default class ChaosiumCanvasInterfaceInit extends ChaosiumCanvasInterface
       ChaosiumCanvasInterfaceDrawingToggle,
       ChaosiumCanvasInterfaceMapPinToggle,
       ChaosiumCanvasInterfaceOpenDocument,
+      ChaosiumCanvasInterfacePlaySound,
       ChaosiumCanvasInterfaceToScene,
       ChaosiumCanvasInterfaceTileToggle
     ]

--- a/module/apps/chaosium-canvas-interface-map-pin-toggle.mjs
+++ b/module/apps/chaosium-canvas-interface-map-pin-toggle.mjs
@@ -18,6 +18,12 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'PEN.ChaosiumCanvasInterface.MapPinToggle.Button.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.MapPinToggle.Button.Hint'
+      }),
       toggle: new fields.BooleanField({
         initial: false,
         label: 'PEN.ChaosiumCanvasInterface.MapPinToggle.Toggle.Title',
@@ -60,7 +66,7 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
     return game.user.isGM
   }
 
-  async _handleLeftClickEvent () {
+  async #handleClickEvent () {
     game.socket.emit('system.Pendragon', { type: 'toggleMapNotes', toggle: true })
     // TODO Remove with v12 support
     game.settings.set('core', (foundry.canvas.layers?.NotesLayer ?? NotesLayer).TOGGLE_SETTING, true)
@@ -81,6 +87,18 @@ export default class ChaosiumCanvasInterfaceMapPinToggle extends ChaosiumCanvasI
       } else {
         console.error('Note ' + uuid + ' not loaded')
       }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if (this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if (this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface-open-document.mjs
+++ b/module/apps/chaosium-canvas-interface-open-document.mjs
@@ -16,6 +16,12 @@ export default class ChaosiumCanvasInterfaceOpenDocument extends ChaosiumCanvasI
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'PEN.ChaosiumCanvasInterface.OpenDocument.Button.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.OpenDocument.Button.Hint'
+      }),
       permission: new fields.StringField({
         blank: false,
         choices: Object.keys(ChaosiumCanvasInterfaceOpenDocument.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceOpenDocument.PERMISSIONS[k]); return c }, {}),
@@ -52,18 +58,28 @@ export default class ChaosiumCanvasInterfaceOpenDocument extends ChaosiumCanvasI
     return false
   }
 
-  async _handleLeftClickEvent () {
-    if (this.documentUuid) {
-      const doc = await fromUuid(this.documentUuid)
-      if (doc?.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)) {
-        if (doc instanceof JournalEntryPage) {
-          doc.parent.sheet.render(true, { pageId: doc.id, anchor: this.anchor })
-        } else {
-          doc.sheet.render(true)
-        }
+  async #handleClickEvent () {
+    const doc = await fromUuid(this.documentUuid)
+    if (doc?.testUserPermission(game.user, CONST.DOCUMENT_OWNERSHIP_LEVELS.OBSERVER)) {
+      if (doc instanceof JournalEntryPage) {
+        doc.parent.sheet.render(true, { pageId: doc.id, anchor: this.anchor })
       } else {
-        console.error('Document ' + this.documentUuid + ' not loaded')
+        doc.sheet.render(true)
       }
+    } else {
+      console.error('Document ' + this.documentUuid + ' not loaded')
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if (this.documentUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if (this.documentUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface-play-sound.mjs
+++ b/module/apps/chaosium-canvas-interface-play-sound.mjs
@@ -1,0 +1,77 @@
+import ChaosiumCanvasInterface from "./chaosium-canvas-interface.mjs";
+
+export default class ChaosiumCanvasInterfacePlaySound extends ChaosiumCanvasInterface {
+  static get icon () {
+    return 'fa-solid fa-music'
+  }
+
+  static defineSchema () {
+    const fields = foundry.data.fields
+    return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'PEN.ChaosiumCanvasInterface.PlaySound.Button.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.PlaySound.Button.Hint'
+      }),
+      toggle: new fields.BooleanField({
+        initial: false,
+        label: 'PEN.ChaosiumCanvasInterface.PlaySound.Toggle.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.PlaySound.Toggle.Hint'
+      }),
+      playlistUuid: new fields.DocumentUUIDField({
+        label: 'PEN.ChaosiumCanvasInterface.PlaySound.Playlist.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.PlaySound.Playlist.Hint',
+        type: 'Playlist'
+      }),
+      soundUuid: new fields.DocumentUUIDField({
+        label: 'PEN.ChaosiumCanvasInterface.PlaySound.Sound.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.PlaySound.Sound.Hint',
+        type: 'PlaylistSound'
+      })
+    }
+  }
+
+  async _handleMouseOverEvent () {
+    return game.user.isGM
+  }
+
+  async #handleClickEvent () {
+    if (this.playlistUuid) {
+      const playList = await fromUuid(this.playlistUuid)
+      if (playList) {
+        if (this.toggle) {
+          playList.playAll()
+        } else {
+          playList.stopAll()
+        }
+      } else {
+        console.error('Playlist ' + this.sceneUuid + ' not loaded')
+      }
+    }
+    if (this.soundUuid) {
+      const sound = await fromUuid(this.soundUuid)
+      if (sound) {
+        if (this.toggle) {
+          sound.parent.playSound(sound)
+        } else {
+          sound.parent.stopSound(sound)
+        }
+      } else {
+        console.error('Sound ' + this.sceneUuid + ' not loaded')
+      }
+    }
+  }
+
+  async _handleLeftClickEvent () {
+    if ((this.playlistUuid || this.soundUuid) && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent () {
+    if ((this.playlistUuid || this.soundUuid) && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
+    }
+  }
+}

--- a/module/apps/chaosium-canvas-interface-to-scene.mjs
+++ b/module/apps/chaosium-canvas-interface-to-scene.mjs
@@ -16,6 +16,12 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
   static defineSchema () {
     const fields = foundry.data.fields
     return {
+      triggerButton: new fields.NumberField({
+        choices: ChaosiumCanvasInterface.triggerButtons,
+        initial: ChaosiumCanvasInterface.triggerButton.Left,
+        label: 'PEN.ChaosiumCanvasInterface.ToScene.Button.Title',
+        hint: 'PEN.ChaosiumCanvasInterface.ToScene.Button.Hint'
+      }),
       permission: new fields.StringField({
         blank: false,
         choices: Object.keys(ChaosiumCanvasInterfaceToScene.PERMISSIONS).reduce((c, k) => { c[k] = game.i18n.localize(ChaosiumCanvasInterfaceToScene.PERMISSIONS[k]); return c }, {}),
@@ -54,16 +60,26 @@ export default class ChaosiumCanvasInterfaceToScene extends ChaosiumCanvasInterf
     return false
   }
 
-  async _handleLeftClickEvent () {
-    if (this.sceneUuid) {
-      const doc = await fromUuid(this.sceneUuid)
-      if (doc) {
-        setTimeout(() => {
-          doc.view()
-        }, 100)
-      } else {
-        console.error('Scene ' + this.sceneUuid + ' not loaded')
-      }
+  async #handleClickEvent () {
+    const doc = await fromUuid(this.sceneUuid)
+    if (doc) {
+      setTimeout(() => {
+        doc.view()
+      }, 100)
+    } else {
+      console.error('Scene ' + this.sceneUuid + ' not loaded')
+    }
+  }
+
+  async _handleLeftClickEvent() {
+    if (this.sceneUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Left) {
+      this.#handleClickEvent()
+    }
+  }
+
+  async _handleRightClickEvent() {
+    if (this.sceneUuid && this.triggerButton === ChaosiumCanvasInterface.triggerButton.Right) {
+      this.#handleClickEvent()
     }
   }
 }

--- a/module/apps/chaosium-canvas-interface.mjs
+++ b/module/apps/chaosium-canvas-interface.mjs
@@ -1,4 +1,18 @@
 export default class ChaosiumCanvasInterface extends foundry.data.regionBehaviors.RegionBehaviorType {
+  static get triggerButtons () {
+    return {
+      [ChaosiumCanvasInterface.triggerButton.Left]: 'PEN.ChaosiumCanvasInterface.Buttons.Left',
+      [ChaosiumCanvasInterface.triggerButton.Right]: 'PEN.ChaosiumCanvasInterface.Buttons.Right'
+    }
+  }
+
+  static get triggerButton () {
+    return {
+      Left: 0,
+      Right: 2
+    }
+  }
+
   static initSelf () {
     // TODO Remove with v12 support
     if (game.release.generation === 12) {
@@ -10,10 +24,16 @@ export default class ChaosiumCanvasInterface extends foundry.data.regionBehavior
       CONFIG.Note.documentClass = NoteDocumentPolyfill
       class TileDocumentPolyfill extends CONFIG.Tile.documentClass {
         get name () {
-          return (this.id)
+          return this.id
         }
       }
       CONFIG.Tile.documentClass = TileDocumentPolyfill
+      class DrawingDocumentPolyfill extends CONFIG.Drawing.documentClass {
+        get name () {
+          return this.id
+        }
+      }
+      CONFIG.Drawing.documentClass = DrawingDocumentPolyfill
     }
 
     // TODO Remove with v12 support

--- a/module/hooks/render-region-behavior-config.mjs
+++ b/module/hooks/render-region-behavior-config.mjs
@@ -1,0 +1,5 @@
+export default function (application, element, context, options) {
+  if (['ChaosiumCanvasInterfaceTileToggle', 'ChaosiumCanvasInterfaceDrawingToggle'].includes(application.document?.type)) {
+    element.querySelector('.window-content')?.classList.add('scrollable')
+  }
+}

--- a/module/hooks/render-region-config.mjs
+++ b/module/hooks/render-region-config.mjs
@@ -1,0 +1,26 @@
+export default function (application, element, context, options) {
+  new (foundry.applications.ux?.DragDrop ?? DragDrop)({
+    permissions: {
+      drop: true
+    },
+    callbacks: {
+      drop: async (event) => {
+        const dataList = JSON.parse(event.dataTransfer.getData('text/plain'))
+        if (typeof dataList.uuid === 'string') {
+          let behaviors = []
+          switch (dataList.type) {
+            case 'RegionBehavior':
+              behaviors = [(await fromUuid(dataList.uuid)).toObject()]
+              break
+            case 'Region':
+              behaviors = (await fromUuid(dataList.uuid)).toObject().behaviors
+              break
+          }
+          if (behaviors.length) {
+            RegionBehavior.create(behaviors, { parent: application.document })
+          }
+        }
+      }
+    }
+  }).bind(element.querySelector('.tab.region-behaviors'))
+}

--- a/module/pendragon.mjs
+++ b/module/pendragon.mjs
@@ -20,7 +20,8 @@ import { PIDEditor } from "./pid/pid-editor.mjs";
 import drawNote from "./hooks/draw-note.mjs";
 import RenderNoteConfig from './hooks/render-note-config.mjs'
 import ChaosiumCanvasInterfaceInit from './apps/chaosium-canvas-interface-init.mjs'
-
+import RenderRegionBehaviorConfig from './hooks/render-region-behavior-config.mjs'
+import RenderRegionConfig from './hooks/render-region-config.mjs'
 
 /* -------------------------------------------- */
 /*  Init Hook                                   */
@@ -78,6 +79,7 @@ Hooks.once("init", async function () {
         }
       });
     });
+    Hooks.on("renderRegionBehaviorConfig", RenderRegionBehaviorConfig);
   }
 
   // Preload Handlebars templates.
@@ -126,6 +128,8 @@ Hooks.on("renderSettingsConfig", (app, html, options) => {
         "</h3>",
     );
 });
+
+Hooks.on('renderRegionConfig', RenderRegionConfig);
 
 PendragonHooks.listen();
 

--- a/system.json
+++ b/system.json
@@ -81,6 +81,7 @@
       "ChaosiumCanvasInterfaceDrawingToggle": {},
       "ChaosiumCanvasInterfaceMapPinToggle": {},
       "ChaosiumCanvasInterfaceOpenDocument": {},
+      "ChaosiumCanvasInterfacePlaySound": {},
       "ChaosiumCanvasInterfaceToScene": {},
       "ChaosiumCanvasInterfaceTileToggle": {}
     }


### PR DESCRIPTION
- Add ability to pick if Left or Right click will trigger the behaviours
- Add CCI: Play Sound
- Add drop existing Region or Region Behaviour on region behaviour config tab to duplicate them [v13 only]
- Add hide permission to Drawing and Tile to prevent always using None

Migrate existing Toggle Drawing and Tile to Both mouse buttons so that trigger regionUuids continues to work, update trigger to the following process
- Trigger Region Button [Left / Right]
- Trigger This Region [Region]
- With A Button Click [Left / Right]